### PR TITLE
Always output Selected property in metadata

### DIFF
--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -266,7 +266,7 @@ func NewMetadata() Metadata {
 //      ]
 type NodeMetadata struct {
 	// Either true or false. Indicates that this node in the schema has been selected by the user for replication.
-	Selected bool `json:"selected,omitempty"`
+	Selected bool `json:"selected"`
 
 	// Either FULL_TABLE, INCREMENTAL, or LOG_BASED. The replication method to use for a stream.
 	ReplicationMethod string `json:"replication-method,omitempty"`


### PR DESCRIPTION
This will make the docs easier to write. Customers can flip this to `true` in their text editor and select columns/tables to be synced.