### PR TITLE
Stitch expects to see timestamp columns as date-time

### DIFF
--- a/cmd/internal/planetscale_edge_mysql.go
+++ b/cmd/internal/planetscale_edge_mysql.go
@@ -216,7 +216,7 @@ func getJsonSchemaType(mysqlType string) StreamProperty {
 		return StreamProperty{Types: []string{"null", "boolean"}}
 	case "date":
 		return StreamProperty{Types: []string{"null", "string"}}
-	case "datetime":
+	case "datetime", "timestamp":
 		return StreamProperty{Types: []string{"null", "string"}, CustomFormat: "date-time"}
 	default:
 		return StreamProperty{Types: []string{"null", "string"}}


### PR DESCRIPTION
From Singer.io's documentation : https://github.com/singer-io/getting-started/blob/master/docs/DISCOVERY_MODE.md#schemas

```
Additionally, it defines a string format called date-time that can be used to indicate when a data point is expected to 
be a [properly formatted](https://tools.ietf.org/html/rfc3339) timestamp string.
```