### PR TITLE
Add support for generating ISO 8601 timestamp values

### DIFF
--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -265,7 +265,11 @@ func (p PlanetScaleEdgeDatabase) printQueryResult(qr *sqltypes.Result, s Stream)
 		for selectedProperty := range s.Schema.Properties {
 			subset[selectedProperty] = datum[selectedProperty]
 			if len(s.Schema.Properties[selectedProperty].CustomFormat) > 0 {
-				subset[selectedProperty] = datum[selectedProperty].(sqltypes.Value).ToString()
+				if s.Schema.Properties[selectedProperty].CustomFormat == "date-time" {
+					subset[selectedProperty] = getISOTimeStamp(datum[selectedProperty].(sqltypes.Value).ToString())
+				} else {
+					subset[selectedProperty] = datum[selectedProperty].(sqltypes.Value).ToString()
+				}
 			}
 		}
 		record := NewRecord()
@@ -273,4 +277,12 @@ func (p PlanetScaleEdgeDatabase) printQueryResult(qr *sqltypes.Result, s Stream)
 		record.Data = subset
 		p.Logger.Record(record, s)
 	}
+}
+
+func getISOTimeStamp(value string) string {
+	p, err := time.Parse("2006-01-02 15:04:05", value)
+	if err != nil {
+		return ""
+	}
+	return p.Format(time.RFC3339)
 }

--- a/cmd/internal/planetscale_edge_mysql.go
+++ b/cmd/internal/planetscale_edge_mysql.go
@@ -214,6 +214,8 @@ func getJsonSchemaType(mysqlType string) StreamProperty {
 	switch mysqlType {
 	case "tinyint(1)":
 		return StreamProperty{Types: []string{"null", "boolean"}}
+	case "double":
+		return StreamProperty{Types: []string{"null", "number"}}
 	case "date":
 		return StreamProperty{Types: []string{"null", "string"}}
 	case "datetime", "timestamp":


### PR DESCRIPTION
When we retrieve values for a `timestamp` column from MySQL, the format of the output is not RFC 3339, which is expected by Stitch. 

To fix this, we need to parse this value *into the RFC3339/ISO8601 format* and print that out to the console. I was able to run through a database table that has timestamp values and import that into Stitch with this PR.


### Before

``` bash
Record 0 for table conviva_facebook_post_metrics did not conform to schema:
#: #: no subschema matched out of the total 2 subschemas
#: expected: null, found: JSONObject
#/bss_last_updated: #: no subschema matched out of the total 2 subschemas
#/bss_last_updated: expected: null, found: String
#/bss_last_updated: [2022-08-01 19:41:04] is not a valid date-time. Expected [yyyy-MM-dd'T'HH:mm:ssZ, yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,9}Z]
```

### After

``` bash
PlanetScale Tap : INFO : [conviva_facebook_post_metrics shard : -] no new rows found, exiting
HTTP Tap : INFO : saving state to path : state/state-1659386195862.json
HTTP Tap : INFO : saving state to path : state/state-1659386195862.json
HTTP Tap : INFO : flushing [4] messages for stream "conviva_facebook_post_metrics"
HTTP Tap : INFO : Server response status : "OK", message : "Batch accepted"
```