### PR TITLE
Fix issue with only first table sync succeeding

### DIFF
--- a/cmd/internal/sync.go
+++ b/cmd/internal/sync.go
@@ -90,9 +90,7 @@ func Sync(ctx context.Context, mysqlDatabase PlanetScaleEdgeMysqlAccess, edgeDat
 }
 
 func generateEmptyState(source PlanetScaleSource, catalog Catalog, shards []string) *State {
-	var s State
-
-	s = State{
+	s := State{
 		Streams: map[string]ShardStates{},
 	}
 

--- a/cmd/internal/sync.go
+++ b/cmd/internal/sync.go
@@ -91,16 +91,16 @@ func Sync(ctx context.Context, mysqlDatabase PlanetScaleEdgeMysqlAccess, edgeDat
 
 func generateEmptyState(source PlanetScaleSource, catalog Catalog, shards []string) *State {
 	var s State
-	initialState, err := source.GetInitialState(source.Database, shards)
-	if err != nil {
-		return nil
-	}
 
 	s = State{
 		Streams: map[string]ShardStates{},
 	}
 
 	for _, stream := range catalog.Streams {
+		initialState, err := source.GetInitialState(source.Database, shards)
+		if err != nil {
+			return nil
+		}
 		s.Streams[stream.Name] = initialState
 	}
 

--- a/cmd/internal/sync_test.go
+++ b/cmd/internal/sync_test.go
@@ -56,7 +56,9 @@ func TestSync_CanStartFromEmptyState(t *testing.T) {
 	var cursor *psdbconnect.TableCursor
 	ped := &testPlanetScaleEdgeDatabase{
 		ReadFn: func(ctx context.Context, ps PlanetScaleSource, s Stream, tc *psdbconnect.TableCursor) (*SerializedCursor, error) {
+			assert.Empty(t, tc.Position, "start position should be empty")
 			cursor = tc
+			cursor.Position = "I-HAVE-MOVED"
 			return TableCursorToSerializedCursor(tc)
 		},
 	}
@@ -72,8 +74,22 @@ func TestSync_CanStartFromEmptyState(t *testing.T) {
 				Metadata: MetadataCollection{
 					{
 						Metadata: NodeMetadata{
-							Selected:   true,
-							BreadCrumb: []string{},
+							ReplicationMethod: "INCREMENTAL",
+							Selected:          true,
+							BreadCrumb:        []string{},
+						},
+					},
+				},
+			},
+			{
+				Name:      "customers",
+				TableName: "customers",
+				Metadata: MetadataCollection{
+					{
+						Metadata: NodeMetadata{
+							ReplicationMethod: "INCREMENTAL",
+							Selected:          true,
+							BreadCrumb:        []string{},
 						},
 					},
 				},


### PR DESCRIPTION
We're seeing an issue with only the sync for the first table succeeding, and other tables returning zero rows. 
Consider two tables : `departments` and `dept_emp `, we start by syncing `departments` and it works. 
``` bash
PlanetScale Tap : INFO : Stream "departments" will be synced incrementally
PlanetScale Tap : INFO : syncing rows from stream "departments" from shard "-"
PlanetScale Tap : INFO : [departments shard : -] peeking to see if there's any new rows
PlanetScale Tap : INFO : new rows found, syncing rows for 1m0s
```

Now, syncing `dept_emp` returns immediately 

``` bash
PlanetScale Tap : INFO : Stream "dept_emp" will be synced incrementally
PlanetScale Tap : INFO : syncing rows from stream "dept_emp" from shard "-"
PlanetScale Tap : INFO : stream's known position is "MySQL56/e42292e8-e28f-11ec-9c5b-d680f5d655b3:1-717,e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-3525,eba743a8-e28f-11ec-9227-62aa711d33c6:1-32"
PlanetScale Tap : INFO :  no new rows found, exiting
```

The second table `dept_emp` should also start from a nil state and not take the state of the last table that synced.

Upon investigating, I found that when we save the state for `departments`, the cursor for `dept_emp` is also moving ahead.

``` bash
	 state before : &{map[departments:{map[-:0xc00007b0f0]} dept_emp:{map[-:0xc00007b0f0]}]}
  // update the state for departments
state.Streams[stream.Name].Shards[shard] = newCursor

	 state after : &{map[departments:{map[-:0xc00007b140]} dept_emp:{map[-:0xc00007b140]}]}
```

As you can see the memory address for both `departments` and `dept_emp`, before saving the cursor for `departments` is the same. As a result, when we update the value for `departments`, we update the cursor for `dept_emp` too.

This is because when we initialize the empty state, the pointer for the empty state is the same across all tables in the schema.

https://github.com/planetscale/singer-tap/blob/7513a0093241bbdf9897981877e6d7ef0836cbec/cmd/internal/sync.go#L92-L108

Here, the pointer `initialState` is reused across all of the tables, instead of the empty state being a unique pointer for each table. This PR fixes the issue by generating unique initial states for each table.