### PR TITLE
Increase Buffer size for STDIN scanner

### DIFF
--- a/cmd/http-tap/main.go
+++ b/cmd/http-tap/main.go
@@ -17,6 +17,7 @@ import (
 var (
 	singerAPIURL   string
 	batchSize      int
+	bufferSize     int
 	apiToken       string
 	stateDirectory string
 )
@@ -26,33 +27,36 @@ func init() {
 	flag.IntVar(&batchSize, "batch-size", 20, "size of each batch sent to Singer, default is 20")
 	flag.StringVar(&apiToken, "api-token", "", "API Token to authenticate with Singer")
 	flag.StringVar(&stateDirectory, "state-directory", "state", "Directory to save any received state, default is state/")
+	flag.IntVar(&bufferSize, "buffer-size", 1024, "size of the buffer used to read lines from STDIN, default is 1024")
 }
 
 func main() {
 	flag.Parse()
 
 	logger := internal.NewLogger("HTTP Tap", os.Stdout, os.Stderr)
-	err := execute(logger, singerAPIURL, batchSize, apiToken)
+	err := execute(logger, singerAPIURL, batchSize, bufferSize, apiToken)
 	if err != nil {
 		logger.Error(err.Error())
 		os.Exit(1)
 	}
 }
 
-func execute(logger internal.Logger, apiUrl string, batchSize int, token string) error {
+func execute(logger internal.Logger, apiUrl string, batchSize, bufferSize int, token string) error {
 
 	if len(token) == 0 {
 		return errors.New("Please specify a valid apiToken with the --api-token flag")
 	}
 
+	maxBufferSize := bufferSize * 1024
+	buf := make([]byte, maxBufferSize)
 	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(buf, maxBufferSize)
 
 	var (
 		stream *internal.Stream
 	)
 
 	batchWriter := internal.NewBatchWriter(batchSize, logger, apiUrl, apiToken)
-
 	for scanner.Scan() {
 		s, r, err := parseInput(scanner.Text(), logger)
 		if err != nil {


### PR DESCRIPTION
When scanning an extra long line from STDIN, the HTTP Tap failed with this error : 
``` bash
HTTP Tap : ERROR : bufio.Scanner: token too long
```

This is because the default buffer size for a `NewScanner` is about 64 KB which is smaller than the size of the string that we're reading. 

https://cs.opensource.google/go/go/+/master:src/bufio/scan.go;l=75-93

Copied here : 
``` golang
const (
	// MaxScanTokenSize is the maximum size used to buffer a token
	// unless the user provides an explicit buffer with Scanner.Buffer.
	// The actual maximum token size may be smaller as the buffer
	// may need to include, for instance, a newline.
	MaxScanTokenSize = 64 * 1024

	startBufSize = 4096 // Size of initial allocation for buffer.
)

// NewScanner returns a new Scanner to read from r.
// The split function defaults to ScanLines.
func NewScanner(r io.Reader) *Scanner {
	return &Scanner{
		r:            r,
		split:        ScanLines,
		maxTokenSize: MaxScanTokenSize,
	}
}
```

The fix here is to override this to be a much larger size, allowing us to read lines of 1 MB in size by default. 
And the user can pass the `buffer-size` argument to increase/reduce this based on their needs.