### PR TITLE
Fix a few bugs with Singer-tap

### DIFF
--- a/cmd/http-tap/main.go
+++ b/cmd/http-tap/main.go
@@ -23,7 +23,7 @@ var (
 
 func init() {
 	flag.StringVar(&singerAPIURL, "api-url", "https://api.stitchdata.com", "API Url for Singer")
-	flag.IntVar(&batchSize, "batch-size", 20, "size of each batch sent to Singer, default is 20")
+	flag.IntVar(&batchSize, "batch-size", 9000, "size of each batch sent to Singer, default is 9000")
 	flag.StringVar(&apiToken, "api-token", "", "API Token to authenticate with Singer")
 	flag.StringVar(&stateDirectory, "state-directory", "state", "Directory to save any received state, default is state/")
 }
@@ -146,10 +146,6 @@ func saveState(logger internal.Logger, input string, path string) error {
 		return errors.Wrap(err, "unable to save state")
 	}
 	return nil
-}
-
-type State struct {
-	Value string `json:"value"`
 }
 
 type MessageType struct {

--- a/cmd/http-tap/main.go
+++ b/cmd/http-tap/main.go
@@ -118,14 +118,29 @@ func parseInput(input string, logger internal.Logger) (*internal.Stream, *intern
 func saveState(logger internal.Logger, input string, path string) error {
 	now := time.Now()
 
+	var st internal.WrappedState
+
+	if err := json.Unmarshal([]byte(input), &st); err != nil {
+		return err
+	}
+
+	stateFileContents, err := json.Marshal(st.Value)
+	if err != nil {
+		return err
+	}
+
 	statePath := filepath.Join(path, fmt.Sprintf("state-%v.json", now.UnixMilli()))
 	logger.Info(fmt.Sprintf("saving state to path : %v", statePath))
 
-	if err := ioutil.WriteFile(statePath, []byte(input), fs.ModePerm); err != nil {
+	if err := ioutil.WriteFile(statePath, stateFileContents, fs.ModePerm); err != nil {
 		logger.Error(fmt.Sprintf("unable to save state to path %v", statePath))
 		return errors.Wrap(err, "unable to save state")
 	}
 	return nil
+}
+
+type State struct {
+	Value string `json:"value"`
 }
 
 type MessageType struct {

--- a/cmd/internal/mock_types.go
+++ b/cmd/internal/mock_types.go
@@ -29,7 +29,7 @@ func (tal *testSingerLogger) Info(message string) {
 type testPlanetScaleEdgeDatabase struct {
 	CanConnectFn        func(ctx context.Context, ps PlanetScaleSource) error
 	CanConnectFnInvoked bool
-	ReadFn              func(ctx context.Context, ps PlanetScaleSource, s Stream, tc *psdbconnect.TableCursor) (*SerializedCursor, error)
+	ReadFn              func(ctx context.Context, ps PlanetScaleSource, s Stream, tc *psdbconnect.TableCursor, indexRows bool) (*SerializedCursor, error)
 	ReadFnInvoked       bool
 }
 
@@ -38,9 +38,9 @@ func (tpe *testPlanetScaleEdgeDatabase) CanConnect(ctx context.Context, ps Plane
 	return tpe.CanConnectFn(ctx, ps)
 }
 
-func (tpe *testPlanetScaleEdgeDatabase) Read(ctx context.Context, ps PlanetScaleSource, s Stream, tc *psdbconnect.TableCursor) (*SerializedCursor, error) {
+func (tpe *testPlanetScaleEdgeDatabase) Read(ctx context.Context, ps PlanetScaleSource, s Stream, tc *psdbconnect.TableCursor, indexRows bool) (*SerializedCursor, error) {
 	tpe.ReadFnInvoked = true
-	return tpe.ReadFn(ctx, ps, s, tc)
+	return tpe.ReadFn(ctx, ps, s, tc, indexRows)
 }
 
 func (tpe *testPlanetScaleEdgeDatabase) Close() error {

--- a/cmd/internal/parser.go
+++ b/cmd/internal/parser.go
@@ -1,0 +1,58 @@
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+	"io/ioutil"
+)
+
+func ParseSavedState(stateFilePath string) (*State, error) {
+	contents, err := ioutil.ReadFile(stateFilePath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to read file at path %v", stateFilePath)
+	}
+
+	return parseSavedStateContents(contents)
+}
+
+func parseSavedStateContents(contents []byte) (*State, error) {
+	var (
+		state        *State
+		wrappedState *WrappedState
+		err          error
+	)
+
+	state, err = ParseContents(contents, state)
+	if err != nil {
+		return nil, fmt.Errorf("state file contents are invalid: %q", err)
+	}
+
+	if state == nil || len(state.Streams) == 0 {
+		wrappedState, err = ParseContents(contents, wrappedState)
+		if err != nil {
+			return nil, fmt.Errorf("state file contents are invalid: %q", err)
+		}
+		if wrappedState != nil {
+			state = &wrappedState.Value
+		}
+	}
+
+	return state, nil
+}
+
+func Parse[T any](path string, obj T) (T, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return obj, errors.Wrapf(err, "unable to read file at path %v", path)
+	}
+
+	return ParseContents(b, obj)
+}
+
+func ParseContents[T any](content []byte, obj T) (T, error) {
+	if err := json.Unmarshal(content, &obj); err != nil {
+		return obj, err
+	}
+	return obj, nil
+}

--- a/cmd/internal/parser_test.go
+++ b/cmd/internal/parser_test.go
@@ -1,0 +1,94 @@
+package internal
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCanUnMarshalWrappedState(t *testing.T) {
+	wrappedStateContents := []byte(`{
+    "type": "STATE",
+    "value":
+    {
+        "bookmarks":
+        {
+            "employees":
+            {
+                "shards":
+                {
+                    "-":
+                    {
+                        "cursor": "CgEtEhBpbXBvcnQtb24tc2NhbGVy"
+                    }
+                }
+            },
+            "salaries":
+            {
+                "shards":
+                {
+                    "-":
+                    {
+                        "cursor": "CgEtEhBpbXBvcnQtb24tc2NhbGVy"
+                    }
+                }
+            },
+            "titles":
+            {
+                "shards":
+                {
+                    "-":
+                    {
+                        "cursor": "CgEtEhBpbXBvcnQtb24tc2NhbGVy"
+                    }
+                }
+            }
+        }
+    }
+}`)
+	state, err := parseSavedStateContents(wrappedStateContents)
+	assert.NoError(t, err)
+	assert.NotNil(t, state)
+	assert.Equal(t, 3, len(state.Streams))
+}
+
+func TestCanUnMarshalState(t *testing.T) {
+	wrappedStateContents := []byte(`{
+    "bookmarks":
+    {
+        "employees":
+        {
+            "shards":
+            {
+                "-":
+                {
+                    "cursor": "CgEtEhBpbXBvcnQtb24tc2NhbGVy"
+                }
+            }
+        },
+        "salaries":
+        {
+            "shards":
+            {
+                "-":
+                {
+                    "cursor": "CgEtEhBpbXBvcnQtb24tc2NhbGVy"
+                }
+            }
+        },
+        "titles":
+        {
+            "shards":
+            {
+                "-":
+                {
+                    "cursor": "CgEtEhBpbXBvcnQtb24tc2NhbGVy"
+                }
+            }
+        }
+    }
+}`)
+	state, err := parseSavedStateContents(wrappedStateContents)
+	assert.NoError(t, err)
+	assert.NotNil(t, state)
+	assert.Equal(t, 3, len(state.Streams))
+}

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -50,7 +50,7 @@ func TestRead_CanPeekBeforeRead(t *testing.T) {
 	cs := Stream{
 		Name: "stream",
 	}
-	sc, err := ped.Read(context.Background(), ps, cs, tc)
+	sc, err := ped.Read(context.Background(), ps, cs, tc, false)
 	assert.NoError(t, err)
 	esc, err := TableCursorToSerializedCursor(tc)
 	assert.NoError(t, err)
@@ -91,7 +91,7 @@ func TestRead_CanEarlyExitIfNoNewVGtidInPeek(t *testing.T) {
 	cs := Stream{
 		Name: "stream",
 	}
-	sc, err := ped.Read(context.Background(), ps, cs, tc)
+	sc, err := ped.Read(context.Background(), ps, cs, tc, false)
 	assert.NoError(t, err)
 	esc, err := TableCursorToSerializedCursor(tc)
 	assert.NoError(t, err)
@@ -133,7 +133,7 @@ func TestRead_CanPickPrimaryForShardedKeyspaces(t *testing.T) {
 	cs := Stream{
 		Name: "stream",
 	}
-	sc, err := ped.Read(context.Background(), ps, cs, tc)
+	sc, err := ped.Read(context.Background(), ps, cs, tc, false)
 	assert.NoError(t, err)
 	esc, err := TableCursorToSerializedCursor(tc)
 	assert.NoError(t, err)
@@ -241,7 +241,7 @@ func TestRead_CanPickPrimaryForUnshardedKeyspaces(t *testing.T) {
 	cs := Stream{
 		Name: "stream",
 	}
-	sc, err := ped.Read(context.Background(), ps, cs, tc)
+	sc, err := ped.Read(context.Background(), ps, cs, tc, false)
 	assert.NoError(t, err)
 	esc, err := TableCursorToSerializedCursor(tc)
 	assert.NoError(t, err)
@@ -285,7 +285,7 @@ func TestRead_CanReturnOriginalCursorIfNoNewFound(t *testing.T) {
 	cs := Stream{
 		Name: "stream",
 	}
-	sc, err := ped.Read(context.Background(), ps, cs, tc)
+	sc, err := ped.Read(context.Background(), ps, cs, tc, false)
 	assert.NoError(t, err)
 	esc, err := TableCursorToSerializedCursor(tc)
 	assert.NoError(t, err)
@@ -333,7 +333,7 @@ func TestRead_CanReturnNewCursorIfNewFound(t *testing.T) {
 	cs := Stream{
 		Name: "stream",
 	}
-	sc, err := ped.Read(context.Background(), ps, cs, tc)
+	sc, err := ped.Read(context.Background(), ps, cs, tc, false)
 	assert.NoError(t, err)
 	esc, err := TableCursorToSerializedCursor(newTC)
 	assert.NoError(t, err)
@@ -414,7 +414,7 @@ func TestRead_CanStopAtWellKnownCursor(t *testing.T) {
 		Name: "customers",
 	}
 
-	sc, err := ped.Read(context.Background(), ps, cs, responses[0].Cursor)
+	sc, err := ped.Read(context.Background(), ps, cs, responses[0].Cursor, false)
 	assert.NoError(t, err)
 	// sync should start at the first vgtid
 	esc, err := TableCursorToSerializedCursor(responses[nextVGtidPosition].Cursor)
@@ -517,7 +517,7 @@ func TestRead_CanLogResults(t *testing.T) {
 			},
 		},
 	}
-	sc, err := ped.Read(context.Background(), ps, cs, tc)
+	sc, err := ped.Read(context.Background(), ps, cs, tc, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, sc)
 	assert.Equal(t, 2, len(tal.records["products"]))

--- a/cmd/internal/sync.go
+++ b/cmd/internal/sync.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func Sync(ctx context.Context, mysqlDatabase PlanetScaleEdgeMysqlAccess, edgeDatabase PlanetScaleDatabase, logger Logger, source PlanetScaleSource, catalog Catalog, state *State) error {
+func Sync(ctx context.Context, mysqlDatabase PlanetScaleEdgeMysqlAccess, edgeDatabase PlanetScaleDatabase, logger Logger, source PlanetScaleSource, catalog Catalog, state *State, indexRows bool) error {
 	// The schema as its stored by Stitch needs to be filtered before it can be synced by the tap.
 	filteredSchema, err := filterSchema(catalog)
 	if err != nil {
@@ -69,7 +69,7 @@ func Sync(ctx context.Context, mysqlDatabase PlanetScaleEdgeMysqlAccess, edgeDat
 				logger.Info(fmt.Sprintf("stream's known position is %q", tc.Position))
 			}
 
-			newCursor, err := edgeDatabase.Read(ctx, source, stream, tc)
+			newCursor, err := edgeDatabase.Read(ctx, source, stream, tc, indexRows)
 			if err != nil {
 				return err
 			}

--- a/cmd/internal/sync.go
+++ b/cmd/internal/sync.go
@@ -28,7 +28,7 @@ func Sync(ctx context.Context, mysqlDatabase PlanetScaleEdgeMysqlAccess, edgeDat
 	}
 
 	// if there is no last known state, start from the beginning.
-	if state == nil {
+	if state == nil || len(state.Streams) == 0 {
 		state = beginningState
 	}
 

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -394,6 +394,10 @@ type State struct {
 	Streams map[string]ShardStates `json:"bookmarks"`
 }
 
+type WrappedState struct {
+	Value State `json:"value"`
+}
+
 type ShardStates struct {
 	Shards map[string]*SerializedCursor `json:"shards"`
 }

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -2,10 +2,6 @@ package internal
 
 import (
 	"encoding/base64"
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-
 	"github.com/pkg/errors"
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
 	"github.com/planetscale/psdb/core/codec"
@@ -408,43 +404,6 @@ type ShardStates struct {
 
 type SerializedCursor struct {
 	Cursor string `json:"cursor"`
-}
-
-func ParseSavedState(stateFilePath string) (*State, error) {
-	var (
-		state        *State
-		wrappedState *WrappedState
-		err          error
-	)
-
-	state, err = Parse(stateFilePath, state)
-	if err != nil {
-		return nil, fmt.Errorf("state file contents are invalid: %q", err)
-	}
-
-	if state == nil || len(state.Streams) == 0 {
-		wrappedState, err = Parse(stateFilePath, wrappedState)
-		if err != nil {
-			return nil, fmt.Errorf("state file contents are invalid: %q", err)
-		}
-		if wrappedState != nil {
-			state = &wrappedState.Value
-		}
-	}
-
-	return state, nil
-}
-
-func Parse[T any](path string, obj T) (T, error) {
-	b, err := ioutil.ReadFile(path)
-	if err != nil {
-		return obj, errors.Wrapf(err, "unable to read file at path %v", path)
-	}
-
-	if err = json.Unmarshal(b, &obj); err != nil {
-		return obj, err
-	}
-	return obj, nil
 }
 
 func (s SerializedCursor) SerializedCursorToTableCursor() (*psdbconnect.TableCursor, error) {

--- a/cmd/singer-tap/main.go
+++ b/cmd/singer-tap/main.go
@@ -53,6 +53,7 @@ func execute(discoverMode bool, logger internal.Logger, configFilePath, catalogF
 		sourceConfig internal.PlanetScaleSource
 		catalog      internal.Catalog
 		state        *internal.State
+		wrappedState *internal.WrappedState
 		err          error
 	)
 
@@ -92,6 +93,15 @@ func execute(discoverMode bool, logger internal.Logger, configFilePath, catalogF
 		state, err = parse(stateFilePath, state)
 		if err != nil {
 			return fmt.Errorf("state file contents are invalid: %q", err)
+		}
+		if state == nil || len(state.Streams) == 0 {
+			wrappedState, err = parse(stateFilePath, wrappedState)
+			if err != nil {
+				return fmt.Errorf("state file contents are invalid: %q", err)
+			}
+			if wrappedState != nil {
+				state = &wrappedState.Value
+			}
 		}
 	}
 

--- a/cmd/singer-tap/main.go
+++ b/cmd/singer-tap/main.go
@@ -22,6 +22,7 @@ var (
 	autoSelect         bool
 	useIncrementalSync bool
 	excludedTables     string
+	indexRows          bool
 )
 
 func init() {
@@ -31,6 +32,7 @@ func init() {
 	flag.StringVar(&stateFilePath, "state", "", "path to state file for this configuration")
 	flag.BoolVar(&autoSelect, "auto-select", false, "(discover mode only) select all tables & columns in the schema")
 	flag.BoolVar(&useIncrementalSync, "incremental", false, "(discover mode only) all tables & views will be synced incrementally")
+	flag.BoolVar(&indexRows, "index-rows", false, "index all rows in the output")
 	flag.StringVar(&excludedTables, "excluded-tables", "", "(discover mode only) comma separated list of tables & views to exclude.")
 }
 
@@ -105,7 +107,7 @@ func sync(ctx context.Context, logger internal.Logger, source internal.PlanetSca
 	defer mysql.Close()
 	ped := internal.NewEdge(mysql, logger)
 
-	return internal.Sync(ctx, mysql, ped, logger, source, catalog, state)
+	return internal.Sync(ctx, mysql, ped, logger, source, catalog, state, indexRows)
 }
 
 func discover(ctx context.Context, logger internal.Logger, source internal.PlanetScaleSource, settings internal.DiscoverSettings) error {

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -828,3 +828,15 @@
     :why: 
     :versions: []
     :when: 2022-07-05 15:16:32.692161000 Z
+- - :approve
+  - github.com/hashicorp/go-cleanhttp
+  - :who: 
+    :why: 
+    :versions: []
+    :when: 2022-08-04 18:06:35.048921000 Z
+- - :approve
+  - github.com/hashicorp/go-retryablehttp
+  - :who: 
+    :why: 
+    :versions: []
+    :when: 2022-08-04 18:06:40.047937000 Z

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,8 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -380,6 +380,8 @@ github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
+github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=


### PR DESCRIPTION
I ran a full end-to-end with the `ps-singer-tap` and `ps-http-tap` and ran into a few issues fixed in this PR : 

1. `ps-http-tap` should output only the `Value` field for the state file.
2. `ps-singer-tap` should support both wrapped and unwrapped state files.
3. `ps-http-tap` is only publishing 65K rows, out of 300K. 
4. `ps-http-tap` was not retrying when Stitch APIs failed to process a request. 
5. Added `--index-rows` to `ps-singer-tap` so we can debug missing rows in the output.