### PR TITLE
Fix field array serialization when using LastKnownPK

### DIFF
--- a/cmd/internal/batch_writer.go
+++ b/cmd/internal/batch_writer.go
@@ -9,8 +9,8 @@ import (
 	"time"
 )
 
-const MaxObjectsInBatch int = 19000
-const MaxBatchRequestSize int = 20 * 1024 * 1024
+const MaxObjectsInBatch int = 1000
+const MaxBatchRequestSize int = 2 * 1024 * 1024
 
 type BatchWriter interface {
 	Flush(stream *Stream) error


### PR DESCRIPTION
## Problem

Given a table that has a composite primary key of `post_id(varchar)`  and `bss_retrieved_on(timestamp)`, we're unable to use the Last saved Primary Key to continue streaming results from VStream. 

## Cause
Taking a look at the error returned from vitess : 

``` sql
"rpc error: code = Unknown desc = rpc error: code = Unknown desc = vttablet: rpc error: code = Unknown desc = You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '03:07:46)
```

Where the query Generated by Vitess is : 
``` sql
SELECT   <field_list>
FROM     <table_name>
WHERE    (
                  post_id = '102982715610066_148825251025812'
         AND      bss_retrieved_on > 2022-07-27 03:07:46)
OR       (
                  post_id > '102982715610066_148825251025812')
ORDER BY post_id,
         bss_retrieved_on
```
We can see that Vitess is assuming that the `2022-07-27 03:07:46` value is an INT32

``` bash
1 copy.go:214] Starting copyTable for conviva_facebook_post_metrics_history, PK [TEXT("102982715610066_148825251025812") INT32(2022-07-27 03:07:46)]
1 engine.go:237] Streaming rows for query SELECT * FROM `conviva_facebook_post_metrics_history`, lastpk: [TEXT("102982715610066_148825251025812") INT32(2022-07-27 03:07:46)]
```

This is because the `Fields` collection that we set on the `TableCursor.LastKnownPK` has **ALL** the fields on the table. 
Not just the primary key fields.

``` bash
name : conviva_account_name type : TEXT
name : conviva_account_id type : INT32
blah blah blah
name : bss_retrieved_on type : TIMESTAMP
```
Given a set of rows like : 
``` bash
102982715610066_148825251025812
2022-07-27 03:07:46
```

Vitess is doing an ordinal assignment by assigning the `2022-07-27 03:07:46` value to the INT32 field in the query


## Resolution
We will filter out all non-key properties from the `Fields` collection in the `TableCursor.LastKnownPK` object before sending the cursor to Edge.