### PR TITLE
Allow singer-tap to stream from a replica, instead of primary.

### DIFF
--- a/cmd/internal/mock_types.go
+++ b/cmd/internal/mock_types.go
@@ -43,9 +43,9 @@ func (tpe *testPlanetScaleEdgeDatabase) CanConnect(ctx context.Context, ps Plane
 	return tpe.CanConnectFn(ctx, ps)
 }
 
-func (tpe *testPlanetScaleEdgeDatabase) Read(ctx context.Context, ps PlanetScaleSource, table Stream, lastKnownPosition *psdbconnect.TableCursor, columns []string, onResult OnResult, onCursor OnCursor) (*SerializedCursor, error) {
+func (tpe *testPlanetScaleEdgeDatabase) Read(ctx context.Context, params ReadParams) (*SerializedCursor, error) {
 	tpe.ReadFnInvoked = true
-	return tpe.ReadFn(ctx, ps, table, lastKnownPosition)
+	return tpe.ReadFn(ctx, params.Source, params.Table, params.LastKnownPosition)
 }
 
 func (tpe *testPlanetScaleEdgeDatabase) Close() error {

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -86,8 +86,10 @@ func (p PlanetScaleEdgeDatabase) Read(ctx context.Context, params ReadParams) (*
 	currentPosition := params.LastKnownPosition
 
 	readDuration := 90 * time.Second
-	preamble := fmt.Sprintf("[%v shard : %v] ", params.Table.Name, currentPosition.Shard)
+	preamble := fmt.Sprintf("[table: %v, shard : %v, tablet: %v] ", params.Table.Name, currentPosition.Shard, params.TabletType)
+
 	for {
+
 		p.Logger.Info(preamble + "peeking to see if there's any new rows")
 		latestCursorPosition, lcErr := p.getLatestCursorPosition(ctx, currentPosition.Shard, currentPosition.Keyspace, params.Table, params.Source, params.TabletType)
 		if lcErr != nil {
@@ -179,6 +181,7 @@ func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.Table
 		Cursor:     tc,
 		TabletType: params.TabletType,
 		Columns:    params.Columns,
+		Cells:      []string{"planetscale_operator_default"},
 	}
 
 	c, err := client.Sync(ctx, sReq)
@@ -296,6 +299,7 @@ func (p PlanetScaleEdgeDatabase) getLatestCursorPosition(ctx context.Context, sh
 			Keyspace: keyspace,
 			Position: "current",
 		},
+		Cells:      []string{"planetscale_operator_default"},
 		TabletType: tabletType,
 	}
 

--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -26,13 +26,23 @@ type (
 	OnCursor func(*psdbconnect.TableCursor) error
 )
 
+type ReadParams struct {
+	Source            PlanetScaleSource
+	Table             Stream
+	LastKnownPosition *psdbconnect.TableCursor
+	Columns           []string
+	OnResult          OnResult
+	OnCursor          OnCursor
+	TabletType        psdbconnect.TabletType
+}
+
 var binlogsPurgedMessage = "Cannot replicate because the master purged required binary logs"
 
 // PlanetScaleDatabase is a general purpose interface
 // that defines all the data access methods needed for the PlanetScale Singer Tap to function.
 type PlanetScaleDatabase interface {
 	CanConnect(ctx context.Context, ps PlanetScaleSource) error
-	Read(ctx context.Context, ps PlanetScaleSource, table Stream, lastKnownPosition *psdbconnect.TableCursor, columns []string, onResult OnResult, onCursor OnCursor) (*SerializedCursor, error)
+	Read(ctx context.Context, params ReadParams) (*SerializedCursor, error)
 	Close() error
 }
 
@@ -66,21 +76,20 @@ func (p PlanetScaleEdgeDatabase) Close() error {
 // 3. Ask vstream to stream from the last known vgtid
 // 4. When we reach the stopping point, read all rows available at this vgtid
 // 5. End the stream when (a) a vgtid newer than latest vgtid is encountered or (b) the timeout kicks in.
-func (p PlanetScaleEdgeDatabase) Read(ctx context.Context, ps PlanetScaleSource, table Stream, lastKnownPosition *psdbconnect.TableCursor, columns []string, onResult OnResult, onCursor OnCursor) (*SerializedCursor, error) {
+func (p PlanetScaleEdgeDatabase) Read(ctx context.Context, params ReadParams) (*SerializedCursor, error) {
 	var (
 		err                     error
 		sErr                    error
 		currentSerializedCursor *SerializedCursor
 	)
 
-	tabletType := psdbconnect.TabletType_primary
-	currentPosition := lastKnownPosition
+	currentPosition := params.LastKnownPosition
 
 	readDuration := 90 * time.Second
-	preamble := fmt.Sprintf("[%v shard : %v] ", table.Name, currentPosition.Shard)
+	preamble := fmt.Sprintf("[%v shard : %v] ", params.Table.Name, currentPosition.Shard)
 	for {
 		p.Logger.Info(preamble + "peeking to see if there's any new rows")
-		latestCursorPosition, lcErr := p.getLatestCursorPosition(ctx, currentPosition.Shard, currentPosition.Keyspace, table, ps, tabletType)
+		latestCursorPosition, lcErr := p.getLatestCursorPosition(ctx, currentPosition.Shard, currentPosition.Keyspace, params.Table, params.Source, params.TabletType)
 		if lcErr != nil {
 			return currentSerializedCursor, errors.Wrap(err, "Unable to get latest cursor position")
 		}
@@ -93,7 +102,7 @@ func (p PlanetScaleEdgeDatabase) Read(ctx context.Context, ps PlanetScaleSource,
 		p.Logger.Info(fmt.Sprintf(preamble+"syncing rows with cursor [%v]", currentPosition))
 		p.Logger.Info(fmt.Sprintf(preamble+"latest database position is [%v]", latestCursorPosition))
 
-		currentPosition, err = p.sync(ctx, currentPosition, latestCursorPosition, table, columns, ps, tabletType, readDuration, onResult, onCursor)
+		currentPosition, err = p.sync(ctx, currentPosition, latestCursorPosition, readDuration, params)
 		if currentPosition.Position != "" {
 			currentSerializedCursor, sErr = TableCursorToSerializedCursor(currentPosition)
 			if sErr != nil {
@@ -105,10 +114,10 @@ func (p PlanetScaleEdgeDatabase) Read(ctx context.Context, ps PlanetScaleSource,
 			if s, ok := status.FromError(err); ok {
 
 				// if the error is unknown, it might be because the binlogs are purged, check for known error message
-				if s.Code() == codes.Unknown && lastKnownPosition != nil {
+				if s.Code() == codes.Unknown && params.LastKnownPosition != nil {
 					if strings.Contains(err.Error(), binlogsPurgedMessage) {
 						p.Logger.Info("Binlogs are purged, state is stale")
-						return currentSerializedCursor, fmt.Errorf("state for this sync operation [%v] is stale, please restart a full sync to get the latest state", lastKnownPosition.Position)
+						return currentSerializedCursor, fmt.Errorf("state for this sync operation [%v] is stale, please restart a full sync to get the latest state", params.LastKnownPosition.Position)
 					}
 				}
 				// if the error is anything other than server timeout, keep going
@@ -119,7 +128,7 @@ func (p PlanetScaleEdgeDatabase) Read(ctx context.Context, ps PlanetScaleSource,
 					p.Logger.Info(preamble + "Continuing with cursor after server timeout")
 				}
 			} else if errors.Is(err, io.EOF) {
-				p.Logger.Info(fmt.Sprintf("%vFinished reading all rows for table [%v]", preamble, table.Name))
+				p.Logger.Info(fmt.Sprintf("%vFinished reading all rows for table [%v]", preamble, params.Table.Name))
 				return currentSerializedCursor, nil
 			} else {
 				p.Logger.Info(fmt.Sprintf("non-grpc error [%v]]", err))
@@ -129,8 +138,8 @@ func (p PlanetScaleEdgeDatabase) Read(ctx context.Context, ps PlanetScaleSource,
 	}
 }
 
-func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.TableCursor, stopPosition string, s Stream, columns []string, ps PlanetScaleSource, tabletType psdbconnect.TabletType, readDuration time.Duration, onResult OnResult, onCursor OnCursor) (*psdbconnect.TableCursor, error) {
-	defer p.Logger.Flush(s)
+func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.TableCursor, stopPosition string, readDuration time.Duration, params ReadParams) (*psdbconnect.TableCursor, error) {
+	defer p.Logger.Flush(params.Table)
 	ctx, cancel := context.WithTimeout(ctx, readDuration)
 	defer cancel()
 
@@ -140,12 +149,12 @@ func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.Table
 	)
 
 	if p.clientFn == nil {
-		conn, err := grpcclient.Dial(ctx, ps.Host,
+		conn, err := grpcclient.Dial(ctx, params.Source.Host,
 			clientoptions.WithDefaultTLSConfig(),
 			clientoptions.WithCompression(true),
 			clientoptions.WithConnectionPool(1),
 			clientoptions.WithExtraCallOption(
-				auth.NewBasicAuth(ps.Username, ps.Password).CallOption(),
+				auth.NewBasicAuth(params.Source.Username, params.Source.Password).CallOption(),
 			),
 		)
 		if err != nil {
@@ -154,22 +163,22 @@ func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.Table
 		defer conn.Close()
 		client = psdbconnect.NewConnectClient(conn)
 	} else {
-		client, err = p.clientFn(ctx, ps)
+		client, err = p.clientFn(ctx, params.Source)
 		if err != nil {
 			return tc, err
 		}
 	}
 
 	if tc.LastKnownPk != nil {
-		filterFields(tc.LastKnownPk, s)
+		filterFields(tc.LastKnownPk, params.Table)
 		tc.Position = ""
 	}
 
 	sReq := &psdbconnect.SyncRequest{
-		TableName:  s.Name,
+		TableName:  params.Table.Name,
 		Cursor:     tc,
-		TabletType: tabletType,
-		Columns:    columns,
+		TabletType: params.TabletType,
+		Columns:    params.Columns,
 	}
 
 	c, err := client.Sync(ctx, sReq)
@@ -205,16 +214,16 @@ func (p PlanetScaleEdgeDatabase) sync(ctx context.Context, tc *psdbconnect.Table
 					Fields: result.Fields,
 				}
 				sqlResult.Rows = append(sqlResult.Rows, row)
-				if onResult != nil {
-					if err := onResult(sqlResult); err != nil {
+				if params.OnResult != nil {
+					if err := params.OnResult(sqlResult); err != nil {
 						return tc, err
 					}
 				}
 			}
 		}
 
-		if onCursor != nil && res.Cursor != nil {
-			onCursor(res.Cursor)
+		if params.OnCursor != nil && res.Cursor != nil {
+			params.OnCursor(res.Cursor)
 		}
 
 		if watchForVgGtidChange && tc.Position != stopPosition {

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -53,7 +53,11 @@ func TestRead_CanPeekBeforeRead(t *testing.T) {
 	cs := Stream{
 		Name: "stream",
 	}
-	sc, err := ped.Read(context.Background(), ps, cs, tc, nil, nil, nil)
+	sc, err := ped.Read(context.Background(), ReadParams{
+		Source:            ps,
+		Table:             cs,
+		LastKnownPosition: tc,
+	})
 	assert.NoError(t, err)
 	esc, err := TableCursorToSerializedCursor(tc)
 	assert.NoError(t, err)
@@ -94,7 +98,11 @@ func TestRead_CanEarlyExitIfNoNewVGtidInPeek(t *testing.T) {
 	cs := Stream{
 		Name: "stream",
 	}
-	sc, err := ped.Read(context.Background(), ps, cs, tc, nil, nil, nil)
+	sc, err := ped.Read(context.Background(), ReadParams{
+		Source:            ps,
+		Table:             cs,
+		LastKnownPosition: tc,
+	})
 	assert.NoError(t, err)
 	esc, err := TableCursorToSerializedCursor(tc)
 	assert.NoError(t, err)
@@ -136,7 +144,11 @@ func TestRead_CanPickPrimaryForShardedKeyspaces(t *testing.T) {
 	cs := Stream{
 		Name: "stream",
 	}
-	sc, err := ped.Read(context.Background(), ps, cs, tc, nil, nil, nil)
+	sc, err := ped.Read(context.Background(), ReadParams{
+		Source:            ps,
+		Table:             cs,
+		LastKnownPosition: tc,
+	})
 	assert.NoError(t, err)
 	esc, err := TableCursorToSerializedCursor(tc)
 	assert.NoError(t, err)
@@ -244,7 +256,11 @@ func TestRead_CanPickPrimaryForUnshardedKeyspaces(t *testing.T) {
 	cs := Stream{
 		Name: "stream",
 	}
-	sc, err := ped.Read(context.Background(), ps, cs, tc, nil, nil, nil)
+	sc, err := ped.Read(context.Background(), ReadParams{
+		Source:            ps,
+		Table:             cs,
+		LastKnownPosition: tc,
+	})
 	assert.NoError(t, err)
 	esc, err := TableCursorToSerializedCursor(tc)
 	assert.NoError(t, err)
@@ -288,7 +304,11 @@ func TestRead_CanReturnOriginalCursorIfNoNewFound(t *testing.T) {
 	cs := Stream{
 		Name: "stream",
 	}
-	sc, err := ped.Read(context.Background(), ps, cs, tc, nil, nil, nil)
+	sc, err := ped.Read(context.Background(), ReadParams{
+		Source:            ps,
+		Table:             cs,
+		LastKnownPosition: tc,
+	})
 	assert.NoError(t, err)
 	esc, err := TableCursorToSerializedCursor(tc)
 	assert.NoError(t, err)
@@ -336,7 +356,12 @@ func TestRead_CanReturnNewCursorIfNewFound(t *testing.T) {
 	cs := Stream{
 		Name: "stream",
 	}
-	sc, err := ped.Read(context.Background(), ps, cs, tc, nil, nil, nil)
+	sc, err := ped.Read(context.Background(), ReadParams{
+		Source:            ps,
+		Table:             cs,
+		LastKnownPosition: tc,
+		TabletType:        psdbconnect.TabletType_primary,
+	})
 	assert.NoError(t, err)
 	esc, err := TableCursorToSerializedCursor(newTC)
 	assert.NoError(t, err)
@@ -419,10 +444,15 @@ func TestRead_CanStopAtWellKnownCursor(t *testing.T) {
 
 	recordCount := 0
 
-	sc, err := ped.Read(context.Background(), ps, cs, responses[0].Cursor, nil, func(*sqltypes.Result) error {
-		recordCount += 1
-		return nil
-	}, nil)
+	sc, err := ped.Read(context.Background(), ReadParams{
+		Source:            ps,
+		Table:             cs,
+		LastKnownPosition: responses[0].Cursor,
+		TabletType:        psdbconnect.TabletType_primary, OnResult: func(qr *sqltypes.Result) error {
+			recordCount++
+			return nil
+		},
+	})
 	assert.NoError(t, err)
 	// sync should start at the first vgtid
 	esc, err := TableCursorToSerializedCursor(responses[nextVGtidPosition].Cursor)
@@ -487,7 +517,12 @@ func TestRead_CanDetectPurgedBinlogs(t *testing.T) {
 		Name: "customers",
 	}
 
-	_, err := ped.Read(context.Background(), ps, cs, staleCursor, nil, nil, nil)
+	_, err := ped.Read(context.Background(), ReadParams{
+		Source:            ps,
+		Table:             cs,
+		LastKnownPosition: staleCursor,
+		TabletType:        psdbconnect.TabletType_primary,
+	})
 	assert.ErrorContains(t, err, "state for this sync operation [e4e20f06-e28f-11ec-8d20-8e7ac09cb64c:1-0] is stale")
 
 	logLines := tal.logMessages
@@ -586,10 +621,16 @@ func TestRead_CanLogResults(t *testing.T) {
 
 	keyboardFound := false
 	monitorFound := false
-	sc, err := ped.Read(context.Background(), ps, cs, tc, nil, func(qr *sqltypes.Result) error {
-		printQueryResult(qr, cs, tal)
-		return nil
-	}, nil)
+	sc, err := ped.Read(context.Background(), ReadParams{
+		Source:            ps,
+		Table:             cs,
+		LastKnownPosition: tc,
+		TabletType:        psdbconnect.TabletType_primary,
+		OnResult: func(qr *sqltypes.Result) error {
+			printQueryResult(qr, cs, tal)
+			return nil
+		},
+	})
 
 	assert.NoError(t, err)
 	assert.NotNil(t, sc)

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -464,7 +464,7 @@ func TestRead_CanStopAtWellKnownCursor(t *testing.T) {
 	assert.Equal(t, 2, cc.syncFnInvokedCount)
 
 	logLines := tal.logMessages
-	assert.Equal(t, "[customers shard : -] Finished reading all rows for table [customers]", logLines[len(logLines)-1])
+	assert.Equal(t, "[table: customers, shard : -, tablet: primary] Finished reading all rows for table [customers]", logLines[len(logLines)-1])
 	assert.Equal(t, 2*(nextVGtidPosition/3), recordCount)
 }
 

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -464,7 +464,7 @@ func TestRead_CanStopAtWellKnownCursor(t *testing.T) {
 	assert.Equal(t, 2, cc.syncFnInvokedCount)
 
 	logLines := tal.logMessages
-	assert.Equal(t, "[table: customers, shard : -, tablet: primary] Finished reading all rows for table [customers]", logLines[len(logLines)-1])
+	assert.Equal(t, "[table: customers, shard : -, tablet: primary, cells : [] ] Finished reading all rows for table [customers]", logLines[len(logLines)-1])
 	assert.Equal(t, 2*(nextVGtidPosition/3), recordCount)
 }
 

--- a/cmd/internal/sync_test.go
+++ b/cmd/internal/sync_test.go
@@ -47,7 +47,7 @@ func TestSync_CanFilterSchema(t *testing.T) {
 			},
 		},
 	}
-	err := Sync(context.Background(), tma, ped, logger, source, catalog, nil, false, logger)
+	err := Sync(context.Background(), tma, ped, logger, source, catalog, nil, logger, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"employees"}, streamsRead, "should filter schema down to only selected tables.")
 }
@@ -98,7 +98,7 @@ func TestSync_CanStartFromEmptyState(t *testing.T) {
 		},
 	}
 
-	err := Sync(context.Background(), tma, ped, logger, source, catalog, nil, false, logger)
+	err := Sync(context.Background(), tma, ped, logger, source, catalog, nil, logger, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, source.Database, cursor.Keyspace)
 	assert.Equal(t, "-", cursor.Shard)
@@ -157,7 +157,7 @@ func TestSync_PrintsStreamSchema(t *testing.T) {
 		},
 	}
 
-	err := Sync(context.Background(), tma, ped, logger, source, catalog, nil, false, logger)
+	err := Sync(context.Background(), tma, ped, logger, source, catalog, nil, logger, 0)
 	assert.Nil(t, err)
 	printedSchema := logger.streamSchemas["employees"]
 	assert.NotNil(t, printedSchema)
@@ -219,7 +219,7 @@ func TestSync_PrintsStreamState(t *testing.T) {
 		},
 	}
 
-	err := Sync(context.Background(), tma, ped, logger, source, catalog, nil, false, logger)
+	err := Sync(context.Background(), tma, ped, logger, source, catalog, nil, logger, 0)
 	assert.Nil(t, err)
 	assert.Len(t, logger.state, 2)
 	lastState := logger.state[1]
@@ -273,7 +273,7 @@ func TestSync_UsesStateIfIncrementalSyncRequested(t *testing.T) {
 		},
 	}
 
-	err = Sync(context.Background(), tma, ped, logger, source, catalog, &lastKnownState, false, logger)
+	err = Sync(context.Background(), tma, ped, logger, source, catalog, &lastKnownState, logger, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, source.Database, cursor.Keyspace)
 	assert.Equal(t, "-", cursor.Shard)
@@ -329,7 +329,7 @@ func TestSync_PrintsOldStateIfNoNewStateFound(t *testing.T) {
 		},
 	}
 
-	err = Sync(context.Background(), tma, ped, logger, source, catalog, &lastKnownState, false, logger)
+	err = Sync(context.Background(), tma, ped, logger, source, catalog, &lastKnownState, logger, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, source.Database, cursor.Keyspace)
 	assert.Equal(t, "-", cursor.Shard)
@@ -399,7 +399,7 @@ func TestSync_PrintsNewStateIfFound(t *testing.T) {
 		},
 	}
 
-	err = Sync(context.Background(), tma, ped, logger, source, catalog, &lastKnownState, false, logger)
+	err = Sync(context.Background(), tma, ped, logger, source, catalog, &lastKnownState, logger, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, source.Database, cursor.Keyspace)
 	assert.Equal(t, "-", cursor.Shard)

--- a/cmd/singer-tap/main.go
+++ b/cmd/singer-tap/main.go
@@ -25,6 +25,7 @@ var (
 	autoSelect         bool
 	useIncrementalSync bool
 	useReplica         bool
+	useReadOnly        bool
 	excludedTables     string
 	singerAPIURL       string
 	batchSize          int
@@ -40,7 +41,8 @@ func init() {
 	flag.BoolVar(&autoSelect, "auto-select", false, "(discover mode only) select all tables & columns in the schema")
 	flag.BoolVar(&useIncrementalSync, "incremental", true, "(discover mode only) all tables & views will be synced incrementally")
 	flag.StringVar(&excludedTables, "excluded-tables", "", "(discover mode only) comma separated list of tables & views to exclude.")
-	flag.BoolVar(&useReplica, "use-replica", false, "(sync mode only) use a replica to stream rows from PlanetScale")
+	flag.BoolVar(&useReplica, "use-replica", false, "(sync mode only) use a replica tablet to stream rows from PlanetScale")
+	flag.BoolVar(&useReadOnly, "use-rdonly", false, "(sync mode only) use a readonly tablet to stream rows from PlanetScale")
 
 	// variables for http commit mode
 	flag.BoolVar(&commitMode, "commit", false, "(sync mode only) Run this tap in commit mode, sends rows to Stitch Import API")
@@ -70,14 +72,27 @@ func main() {
 		recordWriter = logger
 	}
 	logger.Info(fmt.Sprintf("PlanetScale Singer Tap : version [%q], commit [%q], published on [%q]", version, commit, date))
-	err := execute(discoverMode, logger, configFilePath, catalogFilePath, stateFilePath, recordWriter, useReplica)
+	if useReplica && useReadOnly {
+		fmt.Println("Only one of use-replica, use-rdonly can be specified, please pick one of these two modes and try again")
+		os.Exit(1)
+	}
+	var tabletType psdbconnect.TabletType
+	if useReplica {
+		tabletType = psdbconnect.TabletType_replica
+	} else if useReadOnly {
+		tabletType = psdbconnect.TabletType_read_only
+	} else {
+		tabletType = psdbconnect.TabletType_primary
+	}
+
+	err := execute(discoverMode, logger, configFilePath, catalogFilePath, stateFilePath, recordWriter, tabletType)
 	if err != nil {
 		logger.Error(err.Error())
 		os.Exit(1)
 	}
 }
 
-func execute(discoverMode bool, logger internal.Logger, configFilePath, catalogFilePath, stateFilePath string, recordWriter internal.RecordWriter, useReplica bool) error {
+func execute(discoverMode bool, logger internal.Logger, configFilePath, catalogFilePath, stateFilePath string, recordWriter internal.RecordWriter, tabletType psdbconnect.TabletType) error {
 	var (
 		sourceConfig internal.PlanetScaleSource
 		catalog      internal.Catalog
@@ -124,10 +139,10 @@ func execute(discoverMode bool, logger internal.Logger, configFilePath, catalogF
 		}
 	}
 
-	return sync(context.Background(), logger, sourceConfig, catalog, state, recordWriter, useReplica)
+	return sync(context.Background(), logger, sourceConfig, catalog, state, recordWriter, tabletType)
 }
 
-func sync(ctx context.Context, logger internal.Logger, source internal.PlanetScaleSource, catalog internal.Catalog, state *internal.State, recordWriter internal.RecordWriter, useReplica bool) error {
+func sync(ctx context.Context, logger internal.Logger, source internal.PlanetScaleSource, catalog internal.Catalog, state *internal.State, recordWriter internal.RecordWriter, tabletType psdbconnect.TabletType) error {
 	logger.Info(fmt.Sprintf("Syncing records for PlanetScale database : %v", source.Database))
 	mysql, err := internal.NewMySQL(&source)
 	if err != nil {
@@ -136,10 +151,6 @@ func sync(ctx context.Context, logger internal.Logger, source internal.PlanetSca
 	defer mysql.Close()
 	ped := internal.NewEdge(mysql, logger)
 
-	tabletType := psdbconnect.TabletType_primary
-	if useReplica {
-		tabletType = psdbconnect.TabletType_replica
-	}
 	return internal.Sync(ctx, mysql, ped, logger, source, catalog, state, recordWriter, tabletType)
 }
 

--- a/cmd/singer-tap/main.go
+++ b/cmd/singer-tap/main.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 
+	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
+
 	"github.com/pkg/errors"
 	"github.com/planetscale/singer-tap/cmd/internal"
 )
@@ -22,8 +24,8 @@ var (
 	stateFilePath      string
 	autoSelect         bool
 	useIncrementalSync bool
+	useReplica         bool
 	excludedTables     string
-	indexRows          bool
 	singerAPIURL       string
 	batchSize          int
 	apiToken           string
@@ -38,6 +40,7 @@ func init() {
 	flag.BoolVar(&autoSelect, "auto-select", false, "(discover mode only) select all tables & columns in the schema")
 	flag.BoolVar(&useIncrementalSync, "incremental", true, "(discover mode only) all tables & views will be synced incrementally")
 	flag.StringVar(&excludedTables, "excluded-tables", "", "(discover mode only) comma separated list of tables & views to exclude.")
+	flag.BoolVar(&useReplica, "use-replica", false, "(sync mode only) use a replica to stream rows from PlanetScale")
 
 	// variables for http commit mode
 	flag.BoolVar(&commitMode, "commit", false, "(sync mode only) Run this tap in commit mode, sends rows to Stitch Import API")
@@ -67,14 +70,14 @@ func main() {
 		recordWriter = logger
 	}
 	logger.Info(fmt.Sprintf("PlanetScale Singer Tap : version [%q], commit [%q], published on [%q]", version, commit, date))
-	err := execute(discoverMode, logger, configFilePath, catalogFilePath, stateFilePath, recordWriter)
+	err := execute(discoverMode, logger, configFilePath, catalogFilePath, stateFilePath, recordWriter, useReplica)
 	if err != nil {
 		logger.Error(err.Error())
 		os.Exit(1)
 	}
 }
 
-func execute(discoverMode bool, logger internal.Logger, configFilePath, catalogFilePath, stateFilePath string, recordWriter internal.RecordWriter) error {
+func execute(discoverMode bool, logger internal.Logger, configFilePath, catalogFilePath, stateFilePath string, recordWriter internal.RecordWriter, useReplica bool) error {
 	var (
 		sourceConfig internal.PlanetScaleSource
 		catalog      internal.Catalog
@@ -121,10 +124,10 @@ func execute(discoverMode bool, logger internal.Logger, configFilePath, catalogF
 		}
 	}
 
-	return sync(context.Background(), logger, sourceConfig, catalog, state, recordWriter)
+	return sync(context.Background(), logger, sourceConfig, catalog, state, recordWriter, useReplica)
 }
 
-func sync(ctx context.Context, logger internal.Logger, source internal.PlanetScaleSource, catalog internal.Catalog, state *internal.State, recordWriter internal.RecordWriter) error {
+func sync(ctx context.Context, logger internal.Logger, source internal.PlanetScaleSource, catalog internal.Catalog, state *internal.State, recordWriter internal.RecordWriter, useReplica bool) error {
 	logger.Info(fmt.Sprintf("Syncing records for PlanetScale database : %v", source.Database))
 	mysql, err := internal.NewMySQL(&source)
 	if err != nil {
@@ -133,7 +136,11 @@ func sync(ctx context.Context, logger internal.Logger, source internal.PlanetSca
 	defer mysql.Close()
 	ped := internal.NewEdge(mysql, logger)
 
-	return internal.Sync(ctx, mysql, ped, logger, source, catalog, state, indexRows, recordWriter)
+	tabletType := psdbconnect.TabletType_primary
+	if useReplica {
+		tabletType = psdbconnect.TabletType_replica
+	}
+	return internal.Sync(ctx, mysql, ped, logger, source, catalog, state, recordWriter, tabletType)
 }
 
 func discover(ctx context.Context, logger internal.Logger, source internal.PlanetScaleSource, settings internal.DiscoverSettings) error {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/airbyte-source v1.16.0
+	github.com/planetscale/airbyte-source v1.17.0
 	github.com/planetscale/psdb v0.0.0-20220429000526-e2a0e798aaf3
 	github.com/stretchr/testify v1.8.2
 	google.golang.org/grpc v1.53.0

--- a/go.sum
+++ b/go.sum
@@ -624,8 +624,8 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
-github.com/planetscale/airbyte-source v1.16.0 h1:edgR8Vr99XQmCNaInHaAL+xN1a0+d3DjeEBerSUfQv8=
-github.com/planetscale/airbyte-source v1.16.0/go.mod h1:I4jdxCyHAJ/XmJCF7hQOZM2mvUK5FM7hKkUya5IVFDc=
+github.com/planetscale/airbyte-source v1.17.0 h1:UFEu+LNaYuFHNk+gsreAk3ZcK+uZJTMffo/XguvFiC8=
+github.com/planetscale/airbyte-source v1.17.0/go.mod h1:I4jdxCyHAJ/XmJCF7hQOZM2mvUK5FM7hKkUya5IVFDc=
 github.com/planetscale/pargzip v0.0.0-20201116224723-90c7fc03ea8a h1:y0OpQ4+5tKxeh9+H+2cVgASl9yMZYV9CILinKOiKafA=
 github.com/planetscale/psdb v0.0.0-20220429000526-e2a0e798aaf3 h1:oEgD8tPIpxrTTEvVEDsY9pjkJOiqmpOE5kCGnTIGyHM=
 github.com/planetscale/psdb v0.0.0-20220429000526-e2a0e798aaf3/go.mod h1:h30/ekyWqcvoiep4efR5nsNaJxGvyRN+9oTirJg4FRE=


### PR DESCRIPTION
Adds a new CLI flag to allow the singer-tap to stream rows from a replica or a readonly tablet

``` bash
  -use-rdonly
    	(sync mode only) use a readonly tablet to stream rows from PlanetScale
  -use-replica
    	(sync mode only) use a replica tablet to stream rows from PlanetScale
```