### PR TITLE
Ensure empty state for all selected tables

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,9 +7,10 @@ before:
 builds:
   - id: ps-singer-tap
     env:
-      - CGO_ENABLED=1
+      - CGO_ENABLED=0
     goos:
       - darwin
+      - linux
       - windows
     goarch:
       - 386
@@ -27,6 +28,7 @@ builds:
       - CGO_ENABLED=0
     goos:
       - darwin
+      - linux
       - windows
     goarch:
       - 386

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,10 +7,9 @@ before:
 builds:
   - id: ps-singer-tap
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     goos:
       - darwin
-      - linux
       - windows
     goarch:
       - 386
@@ -28,7 +27,6 @@ builds:
       - CGO_ENABLED=0
     goos:
       - darwin
-      - linux
       - windows
     goarch:
       - 386


### PR DESCRIPTION
Closes https://github.com/planetscale/singer-tap/issues/32

We used to ignore the generated empty state and assume that the existing state had all selected tables in it. 
This PR copies over the empty state to the known state, if the table is not known when the state was generated.