### PR TITLE
Do not treat tinyint(1) as boolean by default

### DIFF
--- a/cmd/internal/discover.go
+++ b/cmd/internal/discover.go
@@ -9,9 +9,10 @@ import (
 )
 
 type DiscoverSettings struct {
-	AutoSelectTables   bool
-	ExcludedTables     []string
-	UseIncrementalSync bool
+	AutoSelectTables      bool
+	ExcludedTables        []string
+	UseIncrementalSync    bool
+	TreatTinyIntAsBoolean bool
 }
 
 func Discover(ctx context.Context, source PlanetScaleSource, mysql PlanetScaleEdgeMysqlAccess, settings DiscoverSettings) (Catalog, error) {
@@ -38,7 +39,7 @@ func Discover(ctx context.Context, source PlanetScaleSource, mysql PlanetScaleEd
 			TableName: name,
 		}
 
-		tableSchema, err := mysql.GetTableSchema(ctx, source, name)
+		tableSchema, err := mysql.GetTableSchema(ctx, source, name, settings.TreatTinyIntAsBoolean)
 		if err != nil {
 			return c, errors.Wrapf(err, "unable to retrieve schema for table : %v , failed with : %q", name, err)
 		}

--- a/cmd/internal/mock_types.go
+++ b/cmd/internal/mock_types.go
@@ -149,7 +149,7 @@ func (tma *mysqlAccessMock) GetTableNames(ctx context.Context, source PlanetScal
 	return tma.GetTableNamesFn(ctx, source)
 }
 
-func (tma *mysqlAccessMock) GetTableSchema(ctx context.Context, source PlanetScaleSource, s string) (map[string]StreamProperty, error) {
+func (tma *mysqlAccessMock) GetTableSchema(ctx context.Context, source PlanetScaleSource, s string, b bool) (map[string]StreamProperty, error) {
 	tma.GetTableSchemaFnInvoked = true
 	return tma.GetTableSchemaFn(ctx, source, s)
 }

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -161,9 +161,10 @@ func TestRead_CanPickPrimaryForShardedKeyspaces(t *testing.T) {
 
 func TestDiscover_CanPickRightSingerType(t *testing.T) {
 	tests := []struct {
-		MysqlType      string
-		JSONSchemaType string
-		SingerType     string
+		MysqlType             string
+		JSONSchemaType        string
+		SingerType            string
+		TreatTinyIntAsBoolean bool
 	}{
 		{
 			MysqlType:      "int(32)",
@@ -171,9 +172,16 @@ func TestDiscover_CanPickRightSingerType(t *testing.T) {
 			SingerType:     "",
 		},
 		{
-			MysqlType:      "tinyint(1)",
-			JSONSchemaType: "boolean",
-			SingerType:     "",
+			MysqlType:             "tinyint(1)",
+			JSONSchemaType:        "boolean",
+			SingerType:            "",
+			TreatTinyIntAsBoolean: true,
+		},
+		{
+			MysqlType:             "tinyint(1)",
+			JSONSchemaType:        "integer",
+			SingerType:            "",
+			TreatTinyIntAsBoolean: false,
 		},
 		{
 			MysqlType:      "bigint(16)",
@@ -214,7 +222,7 @@ func TestDiscover_CanPickRightSingerType(t *testing.T) {
 
 	for _, typeTest := range tests {
 		t.Run(fmt.Sprintf("mysql_type_%v", typeTest.MysqlType), func(t *testing.T) {
-			p := getJsonSchemaType(typeTest.MysqlType)
+			p := getJsonSchemaType(typeTest.MysqlType, typeTest.TreatTinyIntAsBoolean)
 			assert.Equal(t, typeTest.SingerType, p.CustomFormat, "wrong custom format")
 			assert.Equal(t, typeTest.JSONSchemaType, p.Types[1], "wrong jsonschema type")
 		})

--- a/cmd/singer-tap/main.go
+++ b/cmd/singer-tap/main.go
@@ -14,23 +14,24 @@ import (
 )
 
 var (
-	version            string
-	commit             string
-	date               string
-	discoverMode       bool
-	commitMode         bool
-	catalogFilePath    string
-	configFilePath     string
-	stateFilePath      string
-	autoSelect         bool
-	useIncrementalSync bool
-	useReplica         bool
-	useReadOnly        bool
-	excludedTables     string
-	singerAPIURL       string
-	batchSize          int
-	apiToken           string
-	stateDirectory     string
+	version               string
+	commit                string
+	date                  string
+	discoverMode          bool
+	commitMode            bool
+	catalogFilePath       string
+	configFilePath        string
+	stateFilePath         string
+	autoSelect            bool
+	useIncrementalSync    bool
+	treatTinyIntAsBoolean bool
+	useReplica            bool
+	useReadOnly           bool
+	excludedTables        string
+	singerAPIURL          string
+	batchSize             int
+	apiToken              string
+	stateDirectory        string
 )
 
 func init() {
@@ -39,6 +40,7 @@ func init() {
 	flag.StringVar(&catalogFilePath, "catalog", "", "(sync mode only) path to a catalog file for this tap")
 	flag.StringVar(&stateFilePath, "state", "", "(sync mode only) path to state file for this configuration")
 	flag.BoolVar(&autoSelect, "auto-select", false, "(discover mode only) select all tables & columns in the schema")
+	flag.BoolVar(&treatTinyIntAsBoolean, "tinyint-as-boolean", false, "(discover mode only) if true, tinyint(1) will be represented as booleans")
 	flag.BoolVar(&useIncrementalSync, "incremental", true, "(discover mode only) all tables & views will be synced incrementally")
 	flag.StringVar(&excludedTables, "excluded-tables", "", "(discover mode only) comma separated list of tables & views to exclude.")
 	flag.BoolVar(&useReplica, "use-replica", false, "(sync mode only) use a replica tablet to stream rows from PlanetScale")
@@ -112,8 +114,9 @@ func execute(discoverMode bool, logger internal.Logger, configFilePath, catalogF
 	if discoverMode {
 		logger.Info("running in discovery mode")
 		settings := internal.DiscoverSettings{
-			AutoSelectTables:   autoSelect,
-			UseIncrementalSync: useIncrementalSync,
+			AutoSelectTables:      autoSelect,
+			UseIncrementalSync:    useIncrementalSync,
+			TreatTinyIntAsBoolean: treatTinyIntAsBoolean,
 		}
 
 		if len(excludedTables) > 0 {


### PR DESCRIPTION
We had this behavior on by default, disabled it and added a new CLI flag. 

``` bash
$ go run ./cmd/singer-tap/main.go -h 2>&1 | grep -1 discover | grep tiny
  -tinyint-as-boolean
    	(discover mode only) if true, tinyint(1) will be represented as booleans
```