### PR TITLE
Serialize values based on Schema information.

### DIFF
--- a/cmd/internal/planetscale_edge_database.go
+++ b/cmd/internal/planetscale_edge_database.go
@@ -320,11 +320,3 @@ func (p PlanetScaleEdgeDatabase) getLatestCursorPosition(ctx context.Context, sh
 		}
 	}
 }
-
-func getISOTimeStamp(value string) string {
-	p, err := time.Parse("2006-01-02 15:04:05", value)
-	if err != nil {
-		return ""
-	}
-	return p.Format(time.RFC3339)
-}

--- a/cmd/internal/planetscale_edge_database_test.go
+++ b/cmd/internal/planetscale_edge_database_test.go
@@ -185,23 +185,20 @@ func TestDiscover_CanPickRightSingerType(t *testing.T) {
 		},
 		{
 			MysqlType:      "bigint(16)",
-			JSONSchemaType: "string",
-			SingerType:     "big_integer",
+			JSONSchemaType: "number",
 		},
 		{
 			MysqlType:      "bigint unsigned",
-			JSONSchemaType: "string",
-			SingerType:     "big_integer",
+			JSONSchemaType: "number",
 		},
 		{
 			MysqlType:      "bigint zerofill",
-			JSONSchemaType: "string",
-			SingerType:     "big_integer",
+			JSONSchemaType: "number",
 		},
 		{
 			MysqlType:      "datetime",
 			JSONSchemaType: "string",
-			SingerType:     "timestamp_with_timezone",
+			SingerType:     "date-time",
 		},
 		{
 			MysqlType:      "date",
@@ -663,8 +660,8 @@ func testLogRecords(t *testing.T, tabletType psdbconnect.TabletType) {
 	records := tal.(*testSingerLogger).records["products"]
 
 	for _, r := range records {
-		id, err := r.Data["pid"].(sqltypes.Value).ToInt64()
-		assert.NoError(t, err)
+		id, ok := r.Data["pid"].(int64)
+		assert.True(t, ok, "pid should be int64")
 
 		_, err = time.Parse(time.RFC3339, r.Data["timestamp"].(string))
 		assert.NoError(t, err, "should print timestamp as ISO 8601/RFC3339 values")
@@ -672,13 +669,13 @@ func testLogRecords(t *testing.T, tabletType psdbconnect.TabletType) {
 		if id == 1 {
 			assert.False(t, keyboardFound, "should not find keyboard twice")
 			keyboardFound = true
-			assert.Equal(t, "keyboard", r.Data["description"].(sqltypes.Value).ToString())
+			assert.Equal(t, "keyboard", r.Data["description"])
 		}
 
 		if id == 2 {
 			assert.False(t, monitorFound, "should not find monitor twice")
 			monitorFound = true
-			assert.Equal(t, "monitor", r.Data["description"].(sqltypes.Value).ToString())
+			assert.Equal(t, "monitor", r.Data["description"])
 		}
 	}
 	assert.True(t, keyboardFound)

--- a/cmd/internal/planetscale_edge_mysql.go
+++ b/cmd/internal/planetscale_edge_mysql.go
@@ -204,11 +204,11 @@ func getJsonSchemaType(mysqlType string, treatTinyIntAsBoolean bool) StreamPrope
 	}
 
 	if strings.HasPrefix(mysqlType, "bigint") {
-		return StreamProperty{Types: []string{"null", "string"}, CustomFormat: "big_integer"}
+		return StreamProperty{Types: []string{"null", "number"}}
 	}
 
 	if strings.HasPrefix(mysqlType, "datetime") {
-		return StreamProperty{Types: []string{"null", "string"}, CustomFormat: "timestamp_with_timezone"}
+		return StreamProperty{Types: []string{"null", "string"}, CustomFormat: "date-time"}
 	}
 
 	if strings.HasSuffix(mysqlType, "int") {

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -2,10 +2,12 @@ package internal
 
 import (
 	"encoding/base64"
+	"strings"
 
 	"github.com/pkg/errors"
 	psdbconnect "github.com/planetscale/airbyte-source/proto/psdbconnect/v1alpha1"
 	"github.com/planetscale/psdb/core/codec"
+
 	"vitess.io/vitess/go/sqltypes"
 )
 
@@ -124,6 +126,31 @@ type StreamSchema struct {
 type StreamProperty struct {
 	Types        []string `json:"type"`
 	CustomFormat string   `json:"format,omitempty"`
+}
+
+func (s StreamProperty) IsBoolean() bool {
+	return s.hasType("boolean")
+}
+
+func (s StreamProperty) IsNumber() bool {
+	return s.hasType("number")
+}
+
+func (s StreamProperty) IsInteger() bool {
+	return s.hasType("integer")
+}
+
+func (s StreamProperty) hasType(typeName string) bool {
+	for _, t := range s.Types {
+		if strings.EqualFold(t, typeName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s StreamProperty) IsDateTime() bool {
+	return s.CustomFormat == "date-time"
 }
 
 type (

--- a/cmd/internal/value_converter.go
+++ b/cmd/internal/value_converter.go
@@ -19,22 +19,21 @@ func Convert(s StreamProperty, value sqltypes.Value) (interface{}, error) {
 		return f, nil
 	}
 
+	// a nil by any other name, is still a nil.
+	if value.IsNull() {
+		return nil, nil
+	}
+
 	// after this, depend on the JSONSchema type to serialize the value.
 	if s.IsDateTime() {
 		return getISOTimeStamp(value), nil
 	} else if s.IsInteger() || s.IsNumber() {
-		if value.IsNull() {
-			return nil, nil
-		}
 		i, err := value.ToInt64()
 		if err != nil {
 			return nil, err
 		}
 		return i, nil
 	} else if s.IsBoolean() {
-		if value.IsNull() {
-			return nil, nil
-		}
 		b, err := value.ToBool()
 		if err != nil {
 			return nil, err

--- a/cmd/internal/value_converter.go
+++ b/cmd/internal/value_converter.go
@@ -1,0 +1,58 @@
+package internal
+
+import (
+	"time"
+
+	"vitess.io/vitess/go/sqltypes"
+)
+
+// Convert will turn the mysql representation of a value
+// into its equivalent JSONSchema compatible representation.
+func Convert(s StreamProperty, value sqltypes.Value) (interface{}, error) {
+	// because JSON schema thinks that both int64 and floats are numbers,
+	// we defer to the persisted value to switch how we serialize this value.
+	if value.IsFloat() {
+		f, err := value.ToFloat64()
+		if err != nil {
+			return nil, err
+		}
+		return f, nil
+	}
+
+	// after this, depend on the JSONSchema type to serialize the value.
+	if s.IsDateTime() {
+		return getISOTimeStamp(value), nil
+	} else if s.IsInteger() || s.IsNumber() {
+		if value.IsNull() {
+			return nil, nil
+		}
+		i, err := value.ToInt64()
+		if err != nil {
+			return nil, err
+		}
+		return i, nil
+	} else if s.IsBoolean() {
+		if value.IsNull() {
+			return nil, nil
+		}
+		b, err := value.ToBool()
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
+	}
+
+	return value.ToString(), nil
+}
+
+func getISOTimeStamp(value sqltypes.Value) interface{} {
+	if value.IsNull() {
+		return nil
+	}
+
+	p, err := time.Parse("2006-01-02 15:04:05", value.ToString())
+	if err != nil {
+		return ""
+	}
+	return p.Format(time.RFC3339)
+}

--- a/cmd/internal/value_converter_test.go
+++ b/cmd/internal/value_converter_test.go
@@ -1,0 +1,109 @@
+package internal
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+func TestCanConvert(t *testing.T) {
+	intValue := strconv.AppendInt(nil, int64(int8(12)), 10)
+	boolTrueValue := strconv.AppendInt(nil, int64(int8(1)), 10)
+	boolfalseValue := strconv.AppendInt(nil, int64(int8(0)), 10)
+	typeTests := []struct {
+		name          string
+		property      StreamProperty
+		value         sqltypes.Value
+		expectedValue interface{}
+	}{
+		{
+			name: "integer",
+			property: StreamProperty{
+				Types: []string{"null", "integer"},
+			},
+			value:         sqltypes.MakeTrusted(querypb.Type_INT8, intValue),
+			expectedValue: int64(12),
+		},
+		{
+			name: "null_integer",
+			property: StreamProperty{
+				Types: []string{"null", "integer"},
+			},
+			value:         sqltypes.MakeTrusted(querypb.Type_NULL_TYPE, []byte("NULL")),
+			expectedValue: nil,
+		},
+		{
+			name: "float64",
+			property: StreamProperty{
+				Types: []string{"null", "number"},
+			},
+			value:         sqltypes.MakeTrusted(querypb.Type_FLOAT64, []byte("3.1415927E+00")),
+			expectedValue: 3.1415927,
+		},
+		{
+			name: "null_float64",
+			property: StreamProperty{
+				Types: []string{"null", "number"},
+			},
+			value:         sqltypes.MakeTrusted(querypb.Type_NULL_TYPE, []byte("NULL")),
+			expectedValue: nil,
+		},
+		{
+			name: "boolean_true",
+			property: StreamProperty{
+				Types: []string{"null", "boolean"},
+			},
+			value:         sqltypes.MakeTrusted(querypb.Type_INT64, boolTrueValue),
+			expectedValue: true,
+		},
+		{
+			name: "boolean_false",
+			property: StreamProperty{
+				Types: []string{"null", "boolean"},
+			},
+			value:         sqltypes.MakeTrusted(querypb.Type_INT64, boolfalseValue),
+			expectedValue: false,
+		},
+		{
+			name: "null_boolean",
+			property: StreamProperty{
+				Types: []string{"null", "number"},
+			},
+			value:         sqltypes.MakeTrusted(querypb.Type_NULL_TYPE, []byte("NULL")),
+			expectedValue: nil,
+		},
+
+		{
+			name: "date-time",
+			property: StreamProperty{
+				Types:        []string{"null", "string"},
+				CustomFormat: "date-time",
+			},
+			value:         sqltypes.MakeTrusted(querypb.Type_DATETIME, []byte("2023-03-23 14:28:21.592111")),
+			expectedValue: "2023-03-23T14:28:21Z",
+		},
+		{
+			name: "date-time-null",
+			property: StreamProperty{
+				Types:        []string{"null", "string"},
+				CustomFormat: "date-time",
+			},
+			value:         sqltypes.MakeTrusted(querypb.Type_NULL_TYPE, []byte("NULL")),
+			expectedValue: nil,
+		},
+	}
+
+	for _, test := range typeTests {
+		t.Run(fmt.Sprintf("test_convert_%v", test.name), func(it *testing.T) {
+			val, err := Convert(test.property, test.value)
+			require.NoError(it, err)
+			assert.Equal(t, test.expectedValue, val)
+		})
+	}
+}


### PR DESCRIPTION
We used to depend on the Stitch Import API's behavior of auto-converting types based on the schema information. 
This doesn't work anymore, instead we need to do this ourselves in the tap.
As a result, we now depend on the schema information to figure out how to serialize a value that can be accepted by the Stitch Import API. 

Added tests for the new behavior
``` bash
> go test -v ./cmd/internal/... -run TestCanConvert
=== RUN   TestCanConvert
=== RUN   TestCanConvert/test_convert_integer
=== RUN   TestCanConvert/test_convert_null_integer
=== RUN   TestCanConvert/test_convert_float64
=== RUN   TestCanConvert/test_convert_null_float64
=== RUN   TestCanConvert/test_convert_boolean_true
=== RUN   TestCanConvert/test_convert_boolean_false
=== RUN   TestCanConvert/test_convert_null_boolean
=== RUN   TestCanConvert/test_convert_date-time
=== RUN   TestCanConvert/test_convert_date-time-null
--- PASS: TestCanConvert (0.00s)
    --- PASS: TestCanConvert/test_convert_integer (0.00s)
    --- PASS: TestCanConvert/test_convert_null_integer (0.00s)
    --- PASS: TestCanConvert/test_convert_float64 (0.00s)
    --- PASS: TestCanConvert/test_convert_null_float64 (0.00s)
    --- PASS: TestCanConvert/test_convert_boolean_true (0.00s)
    --- PASS: TestCanConvert/test_convert_boolean_false (0.00s)
    --- PASS: TestCanConvert/test_convert_null_boolean (0.00s)
    --- PASS: TestCanConvert/test_convert_date-time (0.00s)
    --- PASS: TestCanConvert/test_convert_date-time-null (0.00s)
PASS
```