### PR TITLE
Pass logger to `NewHttpRecordWriter`

### DIFF
--- a/cmd/http-tap/main.go
+++ b/cmd/http-tap/main.go
@@ -54,7 +54,7 @@ func execute(logger internal.Logger, apiUrl string, batchSize, bufferSize int, t
 	var stream *internal.Stream
 
 	recordCount := 0
-	batchWriter := internal.NewHttpRecordWriter(batchSize, apiUrl, apiToken, "", nil)
+	batchWriter := internal.NewHttpRecordWriter(batchSize, apiUrl, apiToken, "", logger)
 	for scanner.Scan() {
 		s, r, err := parseInput(scanner.Text(), logger)
 		if err != nil {


### PR DESCRIPTION
While testing locally with:
```
go run cmd/singer-tap/main.go --config sample/config.json  --catalog sample/catalog.json | go run cmd/http-tap/main.go --api-token <API-TOKEN>
```

I ran into a segfault multiple times at [this log line](https://github.com/planetscale/singer-tap/blob/main/cmd/internal/http_record_writer.go#L77):
```
h.logger.Info(fmt.Sprintf("flushing [%v] messages for stream %q in [%v] batches", len(h.messages), stream.Name, len(batches)))
```

A few `Printf`'s show that the logger is nil at this point:
![Screenshot 2023-12-20 at 9 08 22 AM](https://github.com/planetscale/singer-tap/assets/31225471/735bafca-8c91-4044-84e0-2baf62dc4b97)
![Screenshot 2023-12-20 at 9 08 04 AM](https://github.com/planetscale/singer-tap/assets/31225471/c1fd509b-5d3c-4c0c-bb78-95a86108880b)


This PR makes it so that we pass `logger` when creating the HttpRecordWriter.