### PR TITLE
Create default `state` folder

### DIFF
--- a/cmd/http-tap/main.go
+++ b/cmd/http-tap/main.go
@@ -140,14 +140,12 @@ func saveState(logger internal.Logger, input string, path string) error {
 	}
 
 	// the default state directory is state/; create if it doesn't exist yet
-	if path == "state" {
-		if _, err := os.Stat("state"); os.IsNotExist(err) {
-			logger.Info(fmt.Sprintf("creating state directory at: %v", path))
-			err := os.Mkdir("state", fs.ModePerm)
-			if err != nil {
-				logger.Error(fmt.Sprintf("unable to create state directory at: %v", path))
-				return errors.Wrap(err, "unable to create state directory")
-			}
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		logger.Info(fmt.Sprintf("creating state directory at: %v", path))
+		err := os.Mkdir(path, fs.ModePerm)
+		if err != nil {
+			logger.Error(fmt.Sprintf("unable to create state directory at: %v", path))
+			return errors.Wrap(err, "unable to create state directory")
 		}
 	}
 

--- a/cmd/http-tap/main.go
+++ b/cmd/http-tap/main.go
@@ -139,6 +139,18 @@ func saveState(logger internal.Logger, input string, path string) error {
 		return err
 	}
 
+	// the default state directory is state/; create if it doesn't exist yet
+	if path == "state" {
+		if _, err := os.Stat("state"); os.IsNotExist(err) {
+			logger.Info(fmt.Sprintf("creating state directory at: %v", path))
+			err := os.Mkdir("state", fs.ModePerm)
+			if err != nil {
+				logger.Error(fmt.Sprintf("unable to create state directory at: %v", path))
+				return errors.Wrap(err, "unable to create state directory")
+			}
+		}
+	}
+
 	statePath := filepath.Join(path, fmt.Sprintf("state-%v.json", now.UnixMilli()))
 	logger.Info(fmt.Sprintf("saving state to path : %v", statePath))
 

--- a/cmd/http-tap/main.go
+++ b/cmd/http-tap/main.go
@@ -142,7 +142,7 @@ func saveState(logger internal.Logger, input string, path string) error {
 	// the default state directory is state/; create if it doesn't exist yet
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		logger.Info(fmt.Sprintf("creating state directory at: %v", path))
-		err := os.Mkdir(path, fs.ModePerm)
+		err := os.MkdirAll(path, fs.ModePerm)
 		if err != nil {
 			logger.Error(fmt.Sprintf("unable to create state directory at: %v", path))
 			return errors.Wrap(err, "unable to create state directory")


### PR DESCRIPTION
I noticed this while testing locally. The default `state` directory is set to path `state/`: https://github.com/planetscale/singer-tap/blob/main/cmd/http-tap/main.go#L29. However, [writing the state.json file to the `state/*` path](https://github.com/planetscale/singer-tap/blob/main/cmd/http-tap/main.go#L145) before the directory exists will fail:
![Screenshot 2023-12-20 at 10 11 53 AM](https://github.com/planetscale/singer-tap/assets/31225471/1da06381-caba-4842-98a5-3da0c2b58e45)

~This PR adds some logic to check if the `stateDirectory` is set to the default value `state`, and if so, creates the `state` directory first if it doesn't exist yet.~
**Edit:** Now this logic creates the path directory if the path doesn't exist yet, for all state paths.

With these changes, it now works when not passing a stateDirectory value:
![Screenshot 2023-12-20 at 10 04 43 AM](https://github.com/planetscale/singer-tap/assets/31225471/25468d67-690b-4309-84a9-0a66aede8335)
