### PR TITLE
Use default golang image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -52,7 +52,7 @@ steps:
     command: script/release.sh
     plugins:
       - docker#v3.8.0:
-          image: "pscale.dev/wolfi-prod/go:1.21.3"
+          image: "golang:1.21.3"
           propagate-environment: true
           environment:
             - "GITHUB_TOKEN"


### PR DESCRIPTION
Switches our buildkite release step to use `golang:1.21.3` image.