### PR TITLE
Update goreleaser.yml since nfpms.replacements is deprecated

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -52,7 +52,7 @@ steps:
     command: script/release.sh
     plugins:
       - docker#v3.8.0:
-          image: "pscale.dev/wolfi-prod/go:1.21.3"
+          image: "golang:1.21.3"
           propagate-environment: true
           environment:
             - "GITHUB_TOKEN"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,8 +58,10 @@ nfpms:
     formats:
       - deb
       - rpm
-    replacements:
-      darwin: macOS
+    file_name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_
+      {{- if eq .Os "darwin" }}macOS
+      {{- else }}{{ .Os }}{{ end }}_{{ .Arch }}
 scoop:
   bucket:
     owner: planetscale


### PR DESCRIPTION
`nfpms.replacements` was deprecated here: https://goreleaser.com/deprecations/#archivesreplacements. We should use `file_name_template` instead.