### PR TITLE
Remove scoop

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm64
@@ -26,6 +27,7 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,6 @@ builds:
     goos:
       - darwin
       - linux
-      - windows
     goarch:
       - amd64
       - arm64
@@ -27,7 +26,6 @@ builds:
     goos:
       - darwin
       - linux
-      - windows
     goarch:
       - amd64
       - arm64
@@ -58,13 +56,6 @@ nfpms:
       {{ .ProjectName }}_{{ .Version }}_
       {{- if eq .Os "darwin" }}macOS
       {{- else }}{{ .Os }}{{ end }}_{{ .Arch }}
-scoop:
-  bucket:
-    owner: planetscale
-    name: scoop-bucket
-  homepage: "https://github.com/planetscale/singer-tap"
-  description: "The PlanetScale Singer.io Tap"
-  license: Apache 2.0
 brews:
   - homepage: "https://planetscale.com/"
     description: "The PlanetScale Singer.io Tap"


### PR DESCRIPTION
Scoop requires a single windows archive: https://goreleaser.com/errors/scoop-archive/

We don't want to support windows, so just remove scoop config.