### PR TITLE
Remove type from schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Singer specification for building a tap is available [here](https://github.com/s
 
 Since this is a tap, it can run [Discover mode](https://github.com/singer-io/getting-started/blob/master/docs/DISCOVERY_MODE.md#discovery-mode) or [Sync mode](https://github.com/singer-io/getting-started/blob/master/docs/SYNC_MODE.md#sync-mode)
 
+## Getting Support
+
+If you run into any issues with using this source, please reach out to PlanetScale Support at `support@planetscale.com`
+
 ## Local Development
 **1. Generate config file to connect to your PlanetScale database.** 
 1. Opt-in to Connect for your organization.

--- a/cmd/internal/logger.go
+++ b/cmd/internal/logger.go
@@ -69,7 +69,6 @@ func (sl *singerLogger) StreamSchema(stream Stream) error {
 }
 
 func (sl *singerLogger) Schema(schema Catalog) error {
-	schema.Type = "SCHEMA"
 	return sl.recordEncoder.Encode(schema)
 }
 

--- a/cmd/internal/sync.go
+++ b/cmd/internal/sync.go
@@ -189,9 +189,7 @@ func generateEmptyState(source PlanetScaleSource, catalog Catalog, shards []stri
 
 // filterSchema returns only the selected streams from a given catalog
 func filterSchema(catalog Catalog) (Catalog, error) {
-	filteredCatalog := Catalog{
-		Type: "CATALOG",
-	}
+	filteredCatalog := Catalog{}
 	for _, stream := range catalog.Streams {
 
 		tableMetadata, err := stream.GetTableMetadata()

--- a/cmd/internal/types.go
+++ b/cmd/internal/types.go
@@ -36,7 +36,6 @@ func TableCursorToSerializedCursor(cursor *psdbconnect.TableCursor) (*Serialized
 }
 
 type Catalog struct {
-	Type    string   `json:"type"`
 	Streams []Stream `json:"streams,omitempty"`
 }
 


### PR DESCRIPTION
Resolves #51 
This PR removes the `type` property from the Schema object.